### PR TITLE
OS-X-Voodoo-PS2-Controller Integration - Touchpad Control

### DIFF
--- a/VoodooI2CHID/Info.plist
+++ b/VoodooI2CHID/Info.plist
@@ -100,6 +100,10 @@
 			<string>VoodooI2CPrecisionTouchpadHIDEventDriver</string>
 			<key>IOProviderClass</key>
 			<string>IOHIDInterface</string>
+			<key>RM,deliverNotifications</key>
+			<true/>
+			<key>QuietTimeAfterTyping</key>
+			<integer>500000000</integer>
 		</dict>
 		<key>VoodooI2CHIDDevice Multitouch HID Event Driver</key>
 		<dict>

--- a/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
@@ -83,6 +83,20 @@ const char* VoodooI2CMultitouchHIDEventDriver::getProductName() {
 }
 
 void VoodooI2CMultitouchHIDEventDriver::handleInterruptReport(AbsoluteTime timestamp, IOMemoryDescriptor* report, IOHIDReportType report_type, UInt32 report_id) {
+    
+    // Touchpad is disabled through ApplePS2Keyboard request
+    if (ignoreall)
+        return;
+    
+    uint64_t now_abs;
+    clock_get_uptime(&now_abs);
+    uint64_t now_ns;
+    absolutetime_to_nanoseconds(now_abs, &now_ns);
+    
+    // Ignore touchpad interaction(s) shortly after typing
+    if (now_ns - keytime < maxaftertyping)
+        return;
+    
     if (!readyForReports() || report_type != kIOHIDReportTypeInput)
         return;
 
@@ -715,4 +729,44 @@ bool VoodooI2CMultitouchHIDEventDriver::start(IOService* provider) {
     setProperty("VoodooI2CServices Supported", OSBoolean::withBoolean(true));
 
     return true;
+}
+
+IOReturn VoodooI2CMultitouchHIDEventDriver::message(UInt32 type, IOService* provider, void* argument)
+{
+    IOLog("VoodooI2CMultitouchHIDEventDriver::message: type=%x, provider=%p, argument=%p, argument=%04x\n", type, provider, argument, *static_cast<UInt64*>(argument));
+
+    switch (type)
+    {
+        case kKeyboardGetStatus:
+        {
+            IOLog("%s::getEnabledStatus = %s\n", getName(), ignoreall ? "false" : "true");
+            bool* pResult = (bool*)argument;
+            *pResult = !ignoreall;
+            break;
+        }
+        case kKeyboardSetStatus:
+        {
+            bool enable = *((bool*)argument);
+
+            IOLog("%s::setEnabledStatus = %s\n", getName(), enable ? "true" : "false");
+
+            // ignoreall is true when trackpad has been disabled
+            if (enable == ignoreall)
+            {
+                // save state, and update LED
+                ignoreall = !enable;
+            }
+            break;
+        }
+        case kKeyboardKeyEvent:
+        {
+            //  Remember last time key was pressed
+            keytime = *((uint64_t*)argument);
+            
+            IOLog("%s::keyPressed = %llu\n", getName(), keytime);
+            break;
+        }
+    }
+
+    return kIOReturnSuccess;
 }

--- a/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.hpp
@@ -40,9 +40,14 @@
 
 #define kHIDUsage_Dig_Confidence kHIDUsage_Dig_TouchValid
 
-#define kKeyboardGetStatus iokit_vendor_specific_msg(1)
-#define kKeyboardSetStatus iokit_vendor_specific_msg(2)
-#define kKeyboardKeyEvent iokit_vendor_specific_msg(3)
+// Message types defined by ApplePS2Keyboard
+enum
+{
+    // from keyboard to mouse/touchpad
+    kKeyboardSetTouchStatus = iokit_vendor_specific_msg(100),   // set disable/enable touchpad (data is bool*)
+    kKeyboardGetTouchStatus = iokit_vendor_specific_msg(101),   // get disable/enable touchpad (data is bool*)
+    kKeyboardKeyPressTime = iokit_vendor_specific_msg(110)      // notify of timestamp a non-modifier key was pressed (data is uint64_t*)
+};
 
 /* Implements an HID Event Driver for HID devices that expose a digitiser usage page.
  *
@@ -221,6 +226,14 @@ class VoodooI2CMultitouchHIDEventDriver : public IOHIDEventService {
 
     bool start(IOService* provider);
     
+    /*
+     * Called by ApplePS2Controller to notify of keyboard interactions
+     * @type Custom message type in iokit_vendor_specific_msg range
+     * @provider Calling IOService
+     * @argument Optional argument as defined by message type
+     *
+     * @return kIOSuccess if the message is processed
+     */
     virtual IOReturn message(UInt32 type, IOService* provider, void* argument);
  protected:
     const char* name;

--- a/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.hpp
@@ -40,6 +40,10 @@
 
 #define kHIDUsage_Dig_Confidence kHIDUsage_Dig_TouchValid
 
+#define kKeyboardGetStatus iokit_vendor_specific_msg(1)
+#define kKeyboardSetStatus iokit_vendor_specific_msg(2)
+#define kKeyboardKeyEvent iokit_vendor_specific_msg(3)
+
 /* Implements an HID Event Driver for HID devices that expose a digitiser usage page.
  *
  * The members of this class are responsible for parsing, processing and interpreting digitiser-related HID objects.
@@ -216,6 +220,8 @@ class VoodooI2CMultitouchHIDEventDriver : public IOHIDEventService {
      */
 
     bool start(IOService* provider);
+    
+    virtual IOReturn message(UInt32 type, IOService* provider, void* argument);
  protected:
     const char* name;
     bool awake = true;
@@ -228,6 +234,10 @@ class VoodooI2CMultitouchHIDEventDriver : public IOHIDEventService {
  private:
     SInt32 absolute_axis_removal_percentage = 15;
     OSArray* supported_elements;
+    
+    bool ignoreall;
+    uint64_t maxaftertyping = 500000000;
+    uint64_t keytime = 0;
 };
 
 

--- a/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.cpp
@@ -36,8 +36,6 @@ void VoodooI2CPrecisionTouchpadHIDEventDriver::handleInterruptReport(AbsoluteTim
 }
 
 bool VoodooI2CPrecisionTouchpadHIDEventDriver::handleStart(IOService* provider) {
-    this->setProperty("receiveKeyboardNotifications", true);
-
     if (!super::handleStart(provider))
         return false;
 

--- a/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CPrecisionTouchpadHIDEventDriver.cpp
@@ -28,6 +28,7 @@ void VoodooI2CPrecisionTouchpadHIDEventDriver::enterPrecisionTouchpadMode() {
 }
 
 void VoodooI2CPrecisionTouchpadHIDEventDriver::handleInterruptReport(AbsoluteTime timestamp, IOMemoryDescriptor *report, IOHIDReportType report_type, UInt32 report_id) {
+
     if (!ready)
         return;
 
@@ -35,6 +36,8 @@ void VoodooI2CPrecisionTouchpadHIDEventDriver::handleInterruptReport(AbsoluteTim
 }
 
 bool VoodooI2CPrecisionTouchpadHIDEventDriver::handleStart(IOService* provider) {
+    this->setProperty("receiveKeyboardNotifications", true);
+
     if (!super::handleStart(provider))
         return false;
 


### PR DESCRIPTION
This pull request adds integration for `OS-X-Voodoo-PS2-Controller` in order to enable/disable the touchpad through the `VoodooI2CPrecisionTouchpadHIDEventDriver` driver.

The enabling/disabling is implemented in `VoodooI2CMultitouchHIDEventDriver` and thus can be used on any derived classes through specifying the `RM,deliverNotifications` property.

Additionally the touchpad is temporarily disabled (currently 0.5 seconds, configurable through `QuietTimeAfterTyping` to prevent accidental palm interactions while typing.
This does not apply when using modifier keys for selection (i.e. ctrl + click, windows + click).

The described functionality requires the following pull request for `OS-X-Voodoo-PS2-Controller`:
https://github.com/RehabMan/OS-X-Voodoo-PS2-Controller/pull/158