### PR TITLE
Ignore built-in trackpad when mouse or wireless trackpad is present

### DIFF
--- a/VoodooI2CHID/Info.plist
+++ b/VoodooI2CHID/Info.plist
@@ -104,6 +104,10 @@
 			<true/>
 			<key>QuietTimeAfterTyping</key>
 			<integer>500</integer>
+			<key>ProcessUSBMouseStopsTrackpad</key>
+			<true/>
+			<key>ProcessBluetoothMouseStopsTrackpad</key>
+			<true/>
 		</dict>
 		<key>VoodooI2CHIDDevice Multitouch HID Event Driver</key>
 		<dict>

--- a/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
@@ -8,6 +8,8 @@
 
 #include "VoodooI2CMultitouchHIDEventDriver.hpp"
 #include <IOKit/hid/IOHIDInterface.h>
+#include <IOKit/usb/USBSpec.h>
+#include <IOKit/bluetooth/BluetoothAssignedNumbers.h>
 
 #define GetReportType( type )                                               \
 ((type <= kIOHIDElementTypeInput_ScanCodes) ? kIOHIDReportTypeInput :   \
@@ -85,7 +87,7 @@ const char* VoodooI2CMultitouchHIDEventDriver::getProductName() {
 void VoodooI2CMultitouchHIDEventDriver::handleInterruptReport(AbsoluteTime timestamp, IOMemoryDescriptor* report, IOHIDReportType report_type, UInt32 report_id) {
     
     // Touchpad is disabled through ApplePS2Keyboard request
-    if (ignoreall)
+    if (ignore_all)
         return;
     
     uint64_t now_abs;
@@ -94,7 +96,7 @@ void VoodooI2CMultitouchHIDEventDriver::handleInterruptReport(AbsoluteTime times
     absolutetime_to_nanoseconds(now_abs, &now_ns);
     
     // Ignore touchpad interaction(s) shortly after typing
-    if (now_ns - keytime < maxaftertyping)
+    if (now_ns - key_time < max_after_typing)
         return;
     
     if (!readyForReports() || report_type != kIOHIDReportTypeInput)
@@ -434,11 +436,13 @@ void VoodooI2CMultitouchHIDEventDriver::handleStop(IOService* provider) {
     if (supported_elements)
         OSSafeReleaseNULL(supported_elements);
      */
+    
+    unregisterHIDPointerNotifications();
+    OSSafeReleaseNULL(attachedHIDPointerDevices);
 
     if (multitouch_interface) {
         multitouch_interface->stop(this);
-        multitouch_interface->release();
-        multitouch_interface = NULL;
+        OSSafeReleaseNULL(multitouch_interface);
     }
 
     PMstop();
@@ -726,11 +730,14 @@ bool VoodooI2CMultitouchHIDEventDriver::start(IOService* provider) {
     if (!super::start(provider))
         return false;
     
+    attachedHIDPointerDevices = OSSet::withCapacity(1);
+    registerHIDPointerNotifications();
+
     // Read QuietTimeAfterTyping configuration value (if available)
     OSNumber* quietTimeAfterTyping = OSDynamicCast(OSNumber, getProperty("QuietTimeAfterTyping"));
     
     if (quietTimeAfterTyping != NULL)
-        maxaftertyping = quietTimeAfterTyping->unsigned64BitValue() * 1000000;
+        max_after_typing = quietTimeAfterTyping->unsigned64BitValue() * 1000000;
 
     setProperty("VoodooI2CServices Supported", OSBoolean::withBoolean(true));
 
@@ -747,7 +754,7 @@ IOReturn VoodooI2CMultitouchHIDEventDriver::message(UInt32 type, IOService* prov
             IOLog("%s::getEnabledStatus = %s\n", getName(), ignoreall ? "false" : "true");
 #endif
             bool* pResult = (bool*)argument;
-            *pResult = !ignoreall;
+            *pResult = !ignore_all;
             break;
         }
         case kKeyboardSetTouchStatus:
@@ -757,17 +764,17 @@ IOReturn VoodooI2CMultitouchHIDEventDriver::message(UInt32 type, IOService* prov
             IOLog("%s::setEnabledStatus = %s\n", getName(), enable ? "true" : "false");
 #endif
             // ignoreall is true when trackpad has been disabled
-            if (enable == ignoreall)
+            if (enable == ignore_all)
             {
                 // save state, and update LED
-                ignoreall = !enable;
+                ignore_all = !enable;
             }
             break;
         }
         case kKeyboardKeyPressTime:
         {
             //  Remember last time key was pressed
-            keytime = *((uint64_t*)argument);
+            key_time = *((uint64_t*)argument);
 #if DEBUG
             IOLog("%s::keyPressed = %llu\n", getName(), keytime);
 #endif
@@ -777,3 +784,178 @@ IOReturn VoodooI2CMultitouchHIDEventDriver::message(UInt32 type, IOService* prov
 
     return kIOReturnSuccess;
 }
+
+IOReturn VoodooI2CMultitouchHIDEventDriver::setProperties(OSObject * properties)
+{
+    // Listen for property changes we are interested in (instead of reading these during frequent IO events)
+    OSDictionary* dict = OSDynamicCast(OSDictionary, properties);
+    
+    if (dict != NULL) {
+
+        if (OSCollectionIterator* i = OSCollectionIterator::withCollection(dict))
+        {
+
+            while (OSSymbol* key = OSDynamicCast(OSSymbol, i->getNextObject()))
+            {
+                // System -> Preferences -> Accessibility -> Mouse & Trackpad -> Ignore built-in trackpad when mouse or wireless trackpad is present
+                // USBMouseStopsTrackpad
+                if (key->isEqualTo("USBMouseStopsTrackpad")) {
+                    OSNumber* value = OSDynamicCast(OSNumber, dict->getObject(key));
+
+                    if (value != NULL) {
+                        IOLog("%s::setProperties %s = %d\n", getName(), key->getCStringNoCopy(), value->unsigned32BitValue());
+
+                        ignore_mouse = (value->unsigned32BitValue() > 0);
+                        
+                        // If there are devices connected and automatically switch the current ignore status on/off
+                        if (attachedHIDPointerDevices->getCount() > 0) {
+                            ignore_all = ignore_mouse;
+                        }
+                    }
+                }
+            }
+
+            i->release();
+        }
+    }
+
+    return super::setProperties(properties);
+}
+
+void VoodooI2CMultitouchHIDEventDriver::registerHIDPointerNotifications()
+{
+    IOServiceMatchingNotificationHandler notificationHandler = OSMemberFunctionCast(IOServiceMatchingNotificationHandler, this, &VoodooI2CMultitouchHIDEventDriver::notificationHIDAttachedHandler);
+    
+    // Determine if we should listen for USB mouse attach events as per configuration
+    OSBoolean* isEnabled = OSDynamicCast(OSBoolean, this->getProperty("ProcessUSBMouseStopsTrackpad"));
+
+    if (isEnabled && isEnabled->isTrue()) {
+        // USB mouse HID description as per USB spec: http://www.usb.org/developers/hidpage/HID1_11.pdf
+        OSDictionary* matchingDictionary = serviceMatching("IOUSBInterface");
+
+        propertyMatching(OSSymbol::withCString(kUSBInterfaceClass), OSNumber::withNumber(kUSBHIDInterfaceClass, 8), matchingDictionary);
+        propertyMatching(OSSymbol::withCString(kUSBInterfaceSubClass), OSNumber::withNumber(kUSBHIDBootInterfaceSubClass, 8), matchingDictionary);
+        propertyMatching(OSSymbol::withCString(kUSBInterfaceProtocol), OSNumber::withNumber(kHIDMouseInterfaceProtocol, 8), matchingDictionary);
+
+        // Register for future services
+        usb_hid_publish_notify = addMatchingNotification(gIOFirstPublishNotification, matchingDictionary, notificationHandler, this, NULL, 10000);
+        usb_hid_terminate_notify = addMatchingNotification(gIOTerminatedNotification, matchingDictionary, notificationHandler, this, NULL, 10000);
+        OSSafeReleaseNULL(matchingDictionary);
+    }
+
+    // Determine if we should listen for bluetooth mouse attach events as per configuration
+    isEnabled = OSDynamicCast(OSBoolean, this->getProperty("ProcessBluetoothMouseStopsTrackpad"));
+    
+    if (isEnabled && isEnabled->isTrue()) {
+        // Bluetooth HID devices
+        OSDictionary* matchingDictionary = serviceMatching("IOBluetoothHIDDriver");
+        propertyMatching(OSSymbol::withCString(kIOHIDVirtualHIDevice), OSBoolean::withBoolean(false), matchingDictionary);
+
+        // Register for future services
+        bluetooth_hid_publish_notify = addMatchingNotification(gIOFirstPublishNotification, matchingDictionary, notificationHandler, this, NULL, 10000);
+        bluetooth_hid_terminate_notify = addMatchingNotification(gIOTerminatedNotification, matchingDictionary, notificationHandler, this, NULL, 10000);
+        OSSafeReleaseNULL(matchingDictionary);
+    }
+}
+
+void VoodooI2CMultitouchHIDEventDriver::unregisterHIDPointerNotifications()
+{
+    // Free device matching notifiers
+    if (usb_hid_publish_notify) {
+        usb_hid_publish_notify->remove();
+        OSSafeReleaseNULL(usb_hid_publish_notify);
+    }
+    
+    if (usb_hid_terminate_notify) {
+        usb_hid_terminate_notify->remove();
+        OSSafeReleaseNULL(usb_hid_terminate_notify);
+    }
+    
+    if (bluetooth_hid_publish_notify) {
+        bluetooth_hid_publish_notify->remove();
+        OSSafeReleaseNULL(bluetooth_hid_publish_notify);
+    }
+    
+    if (bluetooth_hid_terminate_notify) {
+        bluetooth_hid_terminate_notify->remove();
+        OSSafeReleaseNULL(bluetooth_hid_terminate_notify);
+    }
+
+    attachedHIDPointerDevices->flushCollection();
+}
+
+bool VoodooI2CMultitouchHIDEventDriver::notificationHIDAttachedHandler(void * refCon,
+                                             IOService * newService,
+                                             IONotifier * notifier)
+{
+    char path[256];
+    int len = 255;
+    memset(path, 0, len);
+    newService->getPath(path, &len, gIOServicePlane);
+
+    if (notifier == usb_hid_publish_notify) {
+        attachedHIDPointerDevices->setObject(newService);
+        IOLog("%s: USB pointer HID device published: %s, # devices: %d\n", getName(), path, attachedHIDPointerDevices->getCount());
+    }
+
+    if (notifier == usb_hid_terminate_notify) {
+        attachedHIDPointerDevices->removeObject(newService);
+        IOLog("%s: USB pointer HID device terminated: %s, # devices: %d\n", getName(), path, attachedHIDPointerDevices->getCount());
+    }
+
+    if (notifier == bluetooth_hid_publish_notify) {
+
+        // Filter on specific CoD (Class of Device) bluetooth devices only
+        OSNumber* propDeviceClass = OSDynamicCast(OSNumber, newService->getProperty("ClassOfDevice"));
+
+        if (propDeviceClass != NULL) {
+
+            long classOfDevice = propDeviceClass->unsigned32BitValue();
+            
+            long deviceClassMajor = (classOfDevice & 0x1F00) >> 8;
+            long deviceClassMinor = (classOfDevice & 0xFF) >> 2;
+            
+            if (deviceClassMajor == kBluetoothDeviceClassMajorPeripheral) { // Bluetooth peripheral devices
+                
+                long deviceClassMinor1 = (deviceClassMinor) & 0x30;
+                long deviceClassMinor2 = (deviceClassMinor) & 0x0F;
+                
+                if (deviceClassMinor1 == kBluetoothDeviceClassMinorPeripheral1Pointing || // Seperate pointing device
+                    deviceClassMinor1 == kBluetoothDeviceClassMinorPeripheral1Combo) // Combo bluetooth keyboard/touchpad
+                {
+                    if (deviceClassMinor2 == kBluetoothDeviceClassMinorPeripheral2Unclassified || // Mouse
+                        deviceClassMinor2 == kBluetoothDeviceClassMinorPeripheral2DigitizerTablet || // Magic Touchpad
+                        deviceClassMinor2 == kBluetoothDeviceClassMinorPeripheral2DigitalPen) // Wacom Tablet
+                    {
+
+                        attachedHIDPointerDevices->setObject(newService);
+                        IOLog("%s: Bluetooth pointer HID device published: %s, # devices: %d\n", getName(), path, attachedHIDPointerDevices->getCount());
+                    }
+                }
+            }
+        }
+    }
+
+    if (notifier == bluetooth_hid_terminate_notify) {
+        attachedHIDPointerDevices->removeObject(newService);
+        IOLog("%s: Bluetooth pointer HID device terminated: %s, # devices: %d\n", getName(), path, attachedHIDPointerDevices->getCount());
+    }
+
+    if (notifier == usb_hid_publish_notify || notifier == bluetooth_hid_publish_notify) {
+        if (ignore_mouse && attachedHIDPointerDevices->getCount() > 0) {
+            // One or more USB or Bluetooth pointer devices attached, disable trackpad
+            ignore_all = true;
+        }
+    }
+
+    if (notifier == usb_hid_terminate_notify || notifier == bluetooth_hid_terminate_notify) {
+        if (ignore_mouse && attachedHIDPointerDevices->getCount() == 0) {
+            // No USB or bluetooth pointer devices attached, re-enable trackpad
+            ignore_all = false;
+        }
+    }
+
+    return true;
+}
+
+

--- a/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.hpp
@@ -262,7 +262,10 @@ class VoodooI2CMultitouchHIDEventDriver : public IOHIDEventService {
     uint64_t max_after_typing = 500000000;
     uint64_t key_time = 0;
     
-    OSSet* attachedHIDPointerDevices;
+    IOWorkLoop* work_loop;
+    IOCommandGate* command_gate;
+    
+    OSSet* attached_hid_pointer_devices;
     
     IONotifier* usb_hid_publish_notify;     // Notification when an USB mouse HID device is connected
     IONotifier* usb_hid_terminate_notify; // Notification when an USB mouse HID device is disconnected
@@ -281,8 +284,14 @@ class VoodooI2CMultitouchHIDEventDriver : public IOHIDEventService {
     void unregisterHIDPointerNotifications();
     
     /*
+     * IOServiceMatchingNotificationHandler (gated) to receive notification of addMatchingNotification registrations
+     * @newService IOService object matching the criteria for the addMatchingNotification registration
+     * @notifier IONotifier object for the notification registration
+     */
+    void notificationHIDAttachedHandlerGated(IOService * newService, IONotifier * notifier);
+    
+    /*
      * IOServiceMatchingNotificationHandler to receive notification of addMatchingNotification registrations
-     * @target target set when registering
      * @refCon reference set when registering
      * @newService IOService object matching the criteria for the addMatchingNotification registration
      * @notifier IONotifier object for the notification registration

--- a/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.hpp
@@ -232,9 +232,17 @@ class VoodooI2CMultitouchHIDEventDriver : public IOHIDEventService {
      * @provider Calling IOService
      * @argument Optional argument as defined by message type
      *
-     * @return kIOSuccess if the message is processed
+     * @return kIOReturnSuccess if the message is processed
      */
     virtual IOReturn message(UInt32 type, IOService* provider, void* argument);
+    
+    /*
+     * Used to pass user preferences from user mode to the driver
+     * @properties OSDictionary of configured properties
+     *
+     * @return kIOReturnSuccess if the properties are received successfully, otherwise kIOUnsupported
+     */
+    virtual IOReturn setProperties(OSObject * properties);
  protected:
     const char* name;
     bool awake = true;
@@ -248,9 +256,38 @@ class VoodooI2CMultitouchHIDEventDriver : public IOHIDEventService {
     SInt32 absolute_axis_removal_percentage = 15;
     OSArray* supported_elements;
     
-    bool ignoreall;
-    uint64_t maxaftertyping = 500000000;
-    uint64_t keytime = 0;
+    bool ignore_all;
+    bool ignore_mouse = false;
+
+    uint64_t max_after_typing = 500000000;
+    uint64_t key_time = 0;
+    
+    OSSet* attachedHIDPointerDevices;
+    
+    IONotifier* usb_hid_publish_notify;     // Notification when an USB mouse HID device is connected
+    IONotifier* usb_hid_terminate_notify; // Notification when an USB mouse HID device is disconnected
+    
+    IONotifier* bluetooth_hid_publish_notify; // Notification when a bluetooth HID device is connected
+    IONotifier* bluetooth_hid_terminate_notify; // Notification when a bluetooth HID device is disconnected
+
+    /*
+     * Register for notifications of attached HID pointer devices (both USB and bluetooth)
+     */
+    void registerHIDPointerNotifications();
+    
+    /*
+     * Unregister for notifications of attached HID pointer devices (both USB and bluetooth)
+     */
+    void unregisterHIDPointerNotifications();
+    
+    /*
+     * IOServiceMatchingNotificationHandler to receive notification of addMatchingNotification registrations
+     * @target target set when registering
+     * @refCon reference set when registering
+     * @newService IOService object matching the criteria for the addMatchingNotification registration
+     * @notifier IONotifier object for the notification registration
+     */
+    bool notificationHIDAttachedHandler(void * refCon, IOService * newService, IONotifier * notifier);
 };
 
 


### PR DESCRIPTION
VoodooI2CHID can now listen for USB or Bluetooth HID devices connecting to the system.

If the device is found to be a pointer device (mouse, trackpad etc), this will disable the built-in trackpad automatically.

Each VoodooI2CHID derived class (for example VoodooI2CPrecisionTouchpadHIDEventDriver), can use this with two new configuration values:
* ProcessUSBMouseStopsTrackpad
* ProcessBluetoothMouseStopsTrackpad

Besides the kext level configuration, the user preference from macOS is taken into account:
`System -> Preferences -> Accessibility -> Mouse & Trackpad -> Ignore built-in trackpad when mouse or wireless trackpad is present`

Though with Bluetooth there can be a slight delay before the disconnection is detected and the touchpad re-enabled, hence its functionality is configurable.

Touchpad enabling and disabling via the PrtScr button works at any time (if the proper VoodooPS2Keyboard driver is installed).