### PR TITLE
High Sierra 17G2208

### DIFF
--- a/VoodooI2CHID/Info.plist
+++ b/VoodooI2CHID/Info.plist
@@ -346,7 +346,7 @@
 		<key>com.apple.iokit.IOACPIFamily</key>
 		<string>1.4</string>
 		<key>com.apple.iokit.IOGraphicsFamily</key>
-		<string>2.4.1</string>
+		<string>1.0.0b1</string>
 		<key>com.apple.iokit.IOHIDFamily</key>
 		<string>2.0</string>
 		<key>com.apple.kpi.iokit</key>
@@ -356,5 +356,7 @@
 		<key>com.apple.kpi.mach</key>
 		<string>13.0</string>
 	</dict>
+	<key>OSBundleRequired</key>
+	<string>Safe Boot</string>
 </dict>
 </plist>

--- a/VoodooI2CHID/Info.plist
+++ b/VoodooI2CHID/Info.plist
@@ -104,10 +104,6 @@
 			<true/>
 			<key>QuietTimeAfterTyping</key>
 			<integer>500</integer>
-			<key>ProcessUSBMouseStopsTrackpad</key>
-			<true/>
-			<key>ProcessBluetoothMouseStopsTrackpad</key>
-			<true/>
 		</dict>
 		<key>VoodooI2CHIDDevice Multitouch HID Event Driver</key>
 		<dict>

--- a/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.hpp
+++ b/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.hpp
@@ -232,17 +232,9 @@ class VoodooI2CMultitouchHIDEventDriver : public IOHIDEventService {
      * @provider Calling IOService
      * @argument Optional argument as defined by message type
      *
-     * @return kIOReturnSuccess if the message is processed
+     * @return kIOSuccess if the message is processed
      */
     virtual IOReturn message(UInt32 type, IOService* provider, void* argument);
-    
-    /*
-     * Used to pass user preferences from user mode to the driver
-     * @properties OSDictionary of configured properties
-     *
-     * @return kIOReturnSuccess if the properties are received successfully, otherwise kIOUnsupported
-     */
-    virtual IOReturn setProperties(OSObject * properties);
  protected:
     const char* name;
     bool awake = true;
@@ -256,38 +248,9 @@ class VoodooI2CMultitouchHIDEventDriver : public IOHIDEventService {
     SInt32 absolute_axis_removal_percentage = 15;
     OSArray* supported_elements;
     
-    bool ignore_all;
-    bool ignore_mouse = false;
-
-    uint64_t max_after_typing = 500000000;
-    uint64_t key_time = 0;
-    
-    OSSet* attachedHIDPointerDevices;
-    
-    IONotifier* usb_hid_publish_notify;     // Notification when an USB mouse HID device is connected
-    IONotifier* usb_hid_terminate_notify; // Notification when an USB mouse HID device is disconnected
-    
-    IONotifier* bluetooth_hid_publish_notify; // Notification when a bluetooth HID device is connected
-    IONotifier* bluetooth_hid_terminate_notify; // Notification when a bluetooth HID device is disconnected
-
-    /*
-     * Register for notifications of attached HID pointer devices (both USB and bluetooth)
-     */
-    void registerHIDPointerNotifications();
-    
-    /*
-     * Unregister for notifications of attached HID pointer devices (both USB and bluetooth)
-     */
-    void unregisterHIDPointerNotifications();
-    
-    /*
-     * IOServiceMatchingNotificationHandler to receive notification of addMatchingNotification registrations
-     * @target target set when registering
-     * @refCon reference set when registering
-     * @newService IOService object matching the criteria for the addMatchingNotification registration
-     * @notifier IONotifier object for the notification registration
-     */
-    bool notificationHIDAttachedHandler(void * refCon, IOService * newService, IONotifier * notifier);
+    bool ignoreall;
+    uint64_t maxaftertyping = 500000000;
+    uint64_t keytime = 0;
 };
 
 


### PR DESCRIPTION
When running High Sierra 17G2208, the following error is encountered:

    Kext com.alexandred.VoodooI2CHID - library kext com.apple.iokit.IOGraphicsFamily not found.
    Can't load kext com.alexandred.VoodooI2CHID - failed to resolve library dependencies.
    Kext com.alexandred.VoodooI2CHID failed to load (0xdc00800e).
    Failed to load kext com.alexandred.VoodooI2CHID (error 0xdc00800e).`

Updating the dependencies for VoodooI2CHID.kext resolves this issue.