### PR TITLE
Fix a panic caused by Touch Bar simulator

### DIFF
--- a/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
@@ -363,7 +363,11 @@ bool VoodooI2CMultitouchHIDEventDriver::handleStart(IOService* provider) {
     if (!hid_interface)
         return false;
 
-    if (hid_interface->getTransport()->getCStringNoCopy() != kIOHIDTransportUSBValue)
+    OSString* transport = hid_interface->getTransport();
+    if (!transport)
+        return false;
+
+    if (transport->getCStringNoCopy() != kIOHIDTransportUSBValue)
         hid_interface->setProperty("VoodooI2CServices Supported", OSBoolean::withBoolean(true));
 
     if (!hid_interface->open(this, 0, OSMemberFunctionCast(IOHIDInterface::InterruptReportAction, this, &VoodooI2CMultitouchHIDEventDriver::handleInterruptReport), NULL))


### PR DESCRIPTION
The Touch Bar simulator is matched by VoodooI2CMultitouchHIDEventDriver, but, as it's not an actual device, IOHIDInterface::getTransport() returns Null. VoodooI2CHID then panics.
With this fix, initialization stops when transport is Null (We don't want to match against virtual devices)

Verified this fix locally and on another user's machine.

This should close https://github.com/alexandred/VoodooI2C/issues/130.