### PR TITLE
Fix kext loading in recovery

### DIFF
--- a/VoodooI2CHID/Info.plist
+++ b/VoodooI2CHID/Info.plist
@@ -361,8 +361,6 @@
 		<string>2.0</string>
 		<key>com.apple.iokit.IOACPIFamily</key>
 		<string>1.4</string>
-		<key>com.apple.iokit.IOGraphicsFamily</key>
-		<string>1.0.0b1</string>
 		<key>com.apple.iokit.IOHIDFamily</key>
 		<string>2.0</string>
 		<key>com.apple.kpi.iokit</key>

--- a/VoodooI2CHID/Info.plist
+++ b/VoodooI2CHID/Info.plist
@@ -373,6 +373,6 @@
 		<string>13.0</string>
 	</dict>
 	<key>OSBundleRequired</key>
-	<string>Safe Boot</string>
+	<string>Root</string>
 </dict>
 </plist>

--- a/VoodooI2CHID/Sensors/VoodooI2CAccelerometerSensor.cpp
+++ b/VoodooI2CHID/Sensors/VoodooI2CAccelerometerSensor.cpp
@@ -13,20 +13,20 @@
 OSDefineMetaClassAndStructors(VoodooI2CAccelerometerSensor, VoodooI2CSensor);
 
 IOFramebuffer* VoodooI2CAccelerometerSensor::getFramebuffer() {
-    IODisplay* display = NULL;
+    IORegistryEntry* display = NULL;
     IOFramebuffer* framebuffer = NULL;
     
     OSDictionary *match = serviceMatching("IODisplay");
     OSIterator *iterator = getMatchingServices(match);
     
     if (iterator) {
-        display = OSDynamicCast(IODisplay, iterator->getNextObject());
+        display = OSDynamicCast(IORegistryEntry, iterator->getNextObject());
         
         if (display) {
             IOLog("%s::Got active display\n", getName());
-            
-            framebuffer = OSDynamicCast(IOFramebuffer, display->getParentEntry(gIOServicePlane)->getParentEntry(gIOServicePlane));
-            
+            IORegistryEntry *entry = display->getParentEntry(gIOServicePlane)->getParentEntry(gIOServicePlane);
+            if (entry)
+                framebuffer = reinterpret_cast<IOFramebuffer*>(entry->metaCast("IOFramebuffer"));
             if (framebuffer)
                 IOLog("%s::Got active framebuffer\n", getName());
         }

--- a/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CTouchscreenHIDEventDriver.cpp
@@ -176,20 +176,20 @@ void VoodooI2CTouchscreenHIDEventDriver::fingerLift() {
 }
 
 IOFramebuffer* VoodooI2CTouchscreenHIDEventDriver::getFramebuffer() {
-    IODisplay* display = NULL;
+    IORegistryEntry* display = NULL;
     IOFramebuffer* framebuffer = NULL;
     
     OSDictionary *match = serviceMatching("IODisplay");
     OSIterator *iterator = getMatchingServices(match);
 
     if (iterator) {
-        display = OSDynamicCast(IODisplay, iterator->getNextObject());
+        display = OSDynamicCast(IORegistryEntry, iterator->getNextObject());
         
         if (display) {
             IOLog("%s::Got active display\n", getName());
-            
-            framebuffer = OSDynamicCast(IOFramebuffer, display->getParentEntry(gIOServicePlane)->getParentEntry(gIOServicePlane));
-            
+            IORegistryEntry *entry = display->getParentEntry(gIOServicePlane)->getParentEntry(gIOServicePlane);
+            if (entry)
+                framebuffer = reinterpret_cast<IOFramebuffer*>(entry->metaCast("IOFramebuffer"));
             if (framebuffer)
                 IOLog("%s::Got active framebuffer\n", getName());
         }


### PR DESCRIPTION
Fix kext loading in recovery. With this fixe my touchpad fully works in recovery and during macos installation.