### PR TITLE
Fix sleep issues

### DIFF
--- a/VoodooI2CHID/VoodooI2CHIDDevice.cpp
+++ b/VoodooI2CHID/VoodooI2CHIDDevice.cpp
@@ -439,6 +439,9 @@ IOReturn VoodooI2CHIDDevice::setPowerState(unsigned long whichState, IOService* 
         return kIOReturnInvalid;
     if (whichState == 0) {
         if (awake) {
+            if (interrupt_simulator) {
+                interrupt_simulator->disable();
+            }
             while (read_in_progress) {
                 IOSleep(100);
             }
@@ -466,6 +469,10 @@ IOReturn VoodooI2CHIDDevice::setPowerState(unsigned long whichState, IOService* 
             read_in_progress = false;
             
             IOLog("%s::%s Woke up\n", getName(), name);
+            if (interrupt_simulator) {
+                interrupt_simulator->setTimeoutMS(200);
+                interrupt_simulator->enable();
+            }
         }
     }
     return kIOPMAckImplied;

--- a/VoodooI2CHID/VoodooI2CHIDDevice.cpp
+++ b/VoodooI2CHID/VoodooI2CHIDDevice.cpp
@@ -424,6 +424,8 @@ IOReturn VoodooI2CHIDDevice::setPowerState(unsigned long whichState, IOService* 
         if (awake) {
             if (interrupt_simulator) {
                 interrupt_simulator->disable();
+            } else {
+                api->disableInterrupt(0);
             }
 
             setHIDPowerState(kVoodooI2CStateOff);
@@ -444,12 +446,15 @@ IOReturn VoodooI2CHIDDevice::setPowerState(unsigned long whichState, IOService* 
             
             api->writeI2C(command.data, 4);
             IOSleep(10);
-            
-            IOLog("%s::%s Woke up\n", getName(), name);
+
             if (interrupt_simulator) {
                 interrupt_simulator->setTimeoutMS(200);
                 interrupt_simulator->enable();
+            } else {
+                api->enableInterrupt(0);
             }
+
+            IOLog("%s::%s Woke up\n", getName(), name);
         }
     }
     return kIOPMAckImplied;

--- a/VoodooI2CHID/VoodooI2CHIDDevice.hpp
+++ b/VoodooI2CHID/VoodooI2CHIDDevice.hpp
@@ -196,7 +196,6 @@ class EXPORT VoodooI2CHIDDevice : public IOHIDDevice {
 
  protected:
     bool awake;
-    bool read_in_progress;
     IOWorkLoop* work_loop;
     
     IOLock* client_lock;

--- a/VoodooI2CHID/VoodooI2CHIDDevice.hpp
+++ b/VoodooI2CHID/VoodooI2CHIDDevice.hpp
@@ -247,6 +247,7 @@ class EXPORT VoodooI2CHIDDevice : public IOHIDDevice {
     IOCommandGate* command_gate;
     UInt16 hid_descriptor_register;
     IOTimerEventSource* interrupt_simulator;
+    IOInterruptEventSource* interrupt_source;
     bool ready_for_input;
     bool* reset_event;
 


### PR DESCRIPTION
- Disable interrupt timer before entering sleep. Fix power state transition timeout in https://github.com/alexandred/VoodooI2C/issues/284.
- Remove `read_in_progress` to avoid the potential race condition. The lock is moved to I2C controller side.
- Disable GPIO interrupt before entering sleep.