### PR TITLE
Remove duplicate setProperty(VoodooI2CServices)

### DIFF
--- a/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
+++ b/VoodooI2CHID/VoodooI2CMultitouchHIDEventDriver.cpp
@@ -818,8 +818,6 @@ bool VoodooI2CMultitouchHIDEventDriver::start(IOService* provider) {
     if (quietTimeAfterTyping != NULL)
         max_after_typing = quietTimeAfterTyping->unsigned64BitValue() * 1000000;
 
-    setProperty("VoodooI2CServices Supported", kOSBooleanTrue);
-
     return true;
 }
 


### PR DESCRIPTION
New laptop time! This time a Lenovo L380 Yoga :D

On sleep, a USB touchscreen will sometimes disconnect. As they have no parent in the VoodooI2C tree, a panic will occur as VoodooI2CServices attemps to disconnect a parent that does not exist.

<img width="1819" height="1116" alt="image" src="https://github.com/user-attachments/assets/8c2d8358-b801-4354-a855-268fd85d2c31" />

Note that in `VoodooI2CMultitouchHIDEventDriver::handleStart`, this property is set as long as the transport is not USB. I'm guessing to try and prevent this from happening? Anyways, as shown here, the I2CServices property is not set anymore. 
<img width="2032" height="1082" alt="image" src="https://github.com/user-attachments/assets/f84a1ce4-2e28-47ff-8de4-e8354a91f67f" />

Note: Draft while I verify overnight this actually fixes the panic haha